### PR TITLE
fix npe on AsyncMethod.equals causing hashmap get to throw NPE.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>net.jmatrix</groupId>
     <artifactId>jmutils</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     
     
    <licenses>

--- a/src/main/java/net/jmatrix/async/AsyncMethod.java
+++ b/src/main/java/net/jmatrix/async/AsyncMethod.java
@@ -139,13 +139,17 @@ public class AsyncMethod<V> extends Observable implements Callable<V>
    public boolean equals(Object o)
    {
       AsyncMethod<?> asyncMethod = (AsyncMethod<?>)o;
+      log.debug("Async method: "+this+"  equals "+o+", args.length="+
+        (args != null ? args.length:"null"));
+      
       boolean result;
       result = target.equals(asyncMethod.getTarget());
       result &= method.equals(asyncMethod.getMethod());
       int i = 0;
       for (Object arg : args)
       {
-         result &= arg.equals(asyncMethod.getArgs()[i++]);
+         result &= ( arg == null && asyncMethod.getArgs()[i] == null) ||
+                   (arg.equals(asyncMethod.getArgs()[i++]));
       }
       return result;
    }

--- a/src/main/java/net/jmatrix/async/AsyncMethod.java
+++ b/src/main/java/net/jmatrix/async/AsyncMethod.java
@@ -139,8 +139,6 @@ public class AsyncMethod<V> extends Observable implements Callable<V>
    public boolean equals(Object o)
    {
       AsyncMethod<?> asyncMethod = (AsyncMethod<?>)o;
-      log.debug("Async method: "+this+"  equals "+o+", args.length="+
-        (args != null ? args.length:"null"));
       
       boolean result;
       result = target.equals(asyncMethod.getTarget());


### PR DESCRIPTION
AsyncDProxy caches the most recent future, whether the cache is enabled or not.  It also looks up the cached Future before it decides whether or not to use it.

However the HashMap lookup of the Future using the AsyncMethod depends on its .equals method - and that throws and NPE if one of the arguments to the previously called method is null.
