### PR TITLE
specify newer jackson-databind version to fix issue raised by snyk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <aspectj.version>1.9.2</aspectj.version>
         <compiler.version>1.8</compiler.version>
         <jackson.version>2.9.9</jackson.version>
+        <jackson.databind.version>2.9.9.3</jackson.databind.version>
     </properties>
     <dependencies>
         <dependency>
@@ -103,7 +104,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
In its analysis of our project, the [Snyk service](https://snyk.io/product/) called out a vulnerability with [jackson-databind](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-450207), a dependency of jmutils.

Summary of issue:

> Affected versions of this package (jackson-databind:2.9.9) are vulnerable to Deserialization of Untrusted Data. A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x through 2.9.9. 

For more info:

https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-450207